### PR TITLE
fix docker build failed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 log = "*"
 log4rs = "*"
-clap = { git = "https://github.com/clap-rs/clap/" }
+clap = "3.0.0-beta.2"
 git-version = "*"
 tonic = "0.2"
 prost = "0.6"

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -41,7 +41,7 @@ impl Notifier {
 
     pub fn fetch_events(&self) -> Vec<NotifyMessage> {
         let mut events = Vec::new();
-        while let Ok(msg) = self.queue.pop() {
+        while let Some(msg) = self.queue.pop() {
             events.push(msg);
         }
         events


### PR DESCRIPTION
docker build error msg:
```
$ cargo build
   Compiling controller v0.1.0 (/home/rink/work/github/cita-cloud/controller_poc)
error[E0308]: mismatched types
  --> src/main.rs:43:13
   |
43 |     subcmd: SubCommand,
   |             ^^^^^^^^^^ expected enum `std::option::Option`, found `&mut SubCommand`
   |
   = note:           expected enum `std::option::Option<(&str, &ArgMatches)>`
           found mutable reference `&mut SubCommand`

error[E0308]: mismatched types
  --> src/sync.rs:44:19
   |
44 |         while let Ok(msg) = self.queue.pop() {
   |                   ^^^^^^^   ---------------- this expression has type `std::option::Option<NotifyMessage>`
   |                   |
   |                   expected enum `std::option::Option`, found enum `std::result::Result`
   |
   = note: expected enum `std::option::Option<NotifyMessage>`
              found enum `std::result::Result<_, _>`
```
reason:
1. clap made some breaking change.
2. `SegQueue` breaking change. return value of `pop` from `Result<T>` to `Option<T>`.

fix:
1. set `clap = "3.0.0-beta.2"` in Cargo.tom
2. change `Ok(msg)` to `Some(msg)`